### PR TITLE
Fix 13 deterministic bugs from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ static/client.js
 node_modules
 scoring-sandbox/node_modules/
 scoring-sandbox/dist/
+.claude

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,265 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "schelling-points",
+      "dependencies": {
+        "howler": "^2.2.4",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+      },
+      "devDependencies": {
+        "@types/express": "^5.0.6",
+        "@types/express-ws": "^3.0.6",
+        "@types/howler": "^2.2.12",
+        "@types/node": "^25.2.3",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "esbuild": "^0.27.3",
+        "express": "^5.2.1",
+        "express-ws": "^5.0.2",
+        "tsx": "^4.21.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/express-ws": ["@types/express-ws@3.0.6", "", { "dependencies": { "@types/express": "*", "@types/express-serve-static-core": "*", "@types/ws": "*" } }, "sha512-6ZDt+tMEQgM4RC1sMX1fIO7kHQkfUDlWfxoPddXUeeDjmc+Yt/fCzqXfp8rFahNr5eIxdomrWphLEWDkB2q3UQ=="],
+
+    "@types/howler": ["@types/howler@2.2.12", "", {}, "sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+
+    "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-ws": ["express-ws@5.0.2", "", { "dependencies": { "ws": "^7.4.6" }, "peerDependencies": { "express": "^4.0.0 || ^5.0.0-alpha.1" } }, "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "howler": ["howler@2.2.4", "", {}, "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
+  }
+}

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -11,10 +11,14 @@ function onMessage(state: t.State, message: t.ToClientMessage): t.State {
     case 'LOUNGE':
       return { ...state, view: { type: 'LOUNGE' } }
 
-    case 'MEMBER_CHANGE':
+    case 'MEMBER_CHANGE': {
+      const viewGameId = 'gameId' in state.view ? state.view.gameId : undefined
+      if (message.gameId !== viewGameId) return state
       return { ...state, otherPlayers: message.allPlayers }
+    }
 
     case 'LOBBY_STATE':
+      console.log(message)
       return { ...state, view: { type: 'LOBBY', gameId: message.gameId, isReady: message.isReady } }
 
     case 'GUESS_STATE':
@@ -23,9 +27,10 @@ function onMessage(state: t.State, message: t.ToClientMessage): t.State {
     case 'SCORE_STATE':
       return { ...state, view: { type: 'SCORES', gameId: message.gameId, scores: message.playerScores, category: message.category } }
 
-    case 'LOBBY_COUNTDOWN':
-      // TODO: start countdown animation
-      return state
+    case 'LOBBY_COUNTDOWN': {
+      const isReady = state.view.type === 'LOBBY' ? state.view.isReady : []
+      return { ...state, view: { type: 'LOBBY', gameId: message.gameId, isReady, secsLeft: message.secsLeft } }
+    }
 
     case 'NO_SUCH_GAME':
       // TODO: Create notification?
@@ -45,6 +50,7 @@ function App() {
       return <Lounge
         mailbox={state.mailbox}
         playerId={state.playerId}
+        mood={state.mood}
         otherPlayers={state.otherPlayers}
       />
 
@@ -54,6 +60,7 @@ function App() {
         playerId={state.playerId}
         gameId={state.view.gameId}
         isReady={state.view.isReady}
+        secsLeft={state.view.secsLeft}
         otherPlayers={state.otherPlayers}
       />
 

--- a/src/client/Lobby.tsx
+++ b/src/client/Lobby.tsx
@@ -6,16 +6,17 @@ type Props = {
   playerId: t.PlayerId
   gameId: t.GameId
   isReady: [t.PlayerId, boolean][]
+  secsLeft?: number
   otherPlayers: [t.PlayerId, t.PlayerName, t.Mood][]
 }
 
-export function Lobby({ mailbox, playerId, gameId, isReady, otherPlayers }: Props) {
+export function Lobby({ mailbox, playerId, gameId, isReady, secsLeft, otherPlayers }: Props) {
   // Build a name lookup from otherPlayers
   const nameOf = new Map(otherPlayers.map(([id, name]) => [id, name]))
 
   function handleToggleReady() {
     const currentlyReady = isReady.find(([id]) => id === playerId)?.[1] ?? false
-    mailbox.send({ type: 'READY', gameId, isReady: !currentlyReady })
+    mailbox.send({ type: 'READY', gameId, playerId, isReady: !currentlyReady })
   }
 
   return (
@@ -28,9 +29,12 @@ export function Lobby({ mailbox, playerId, gameId, isReady, otherPlayers }: Prop
           </li>
         ))}
       </ul>
-      <button onClick={handleToggleReady}>
-        {isReady.find(([id]) => id === playerId)?.[1] ? 'Unready' : 'Ready'}
-      </button>
+      {secsLeft !== undefined
+        ? <p>Starting in {Math.ceil(secsLeft)}...</p>
+        : <button onClick={handleToggleReady}>
+            {isReady.find(([id]) => id === playerId)?.[1] ? 'Unready' : 'Ready'}
+          </button>
+      }
       {/* TODO: QR code + copy URL for sharing */}
     </div>
   )

--- a/src/client/Lounge.tsx
+++ b/src/client/Lounge.tsx
@@ -5,21 +5,24 @@ import { Box } from './mail'
 type Props = {
   mailbox: Box
   playerId: t.PlayerId
+  mood: t.Mood
   otherPlayers: [t.PlayerId, t.PlayerName, t.Mood][]
 }
 
-export function Lounge({ mailbox, playerId, otherPlayers }: Props) {
-  const [playerName, setPlayerName] = React.useState('')
+export function Lounge({ mailbox, playerId, mood, otherPlayers }: Props) {
+  const savedName = localStorage.getItem('playerName') ?? ''
+  const [playerName, setPlayerName] = React.useState(savedName)
   const [joined, setJoined] = React.useState(false)
 
   function handleJoin() {
     if (!playerName.trim()) return
-    mailbox.send({ type: 'JOIN_LOUNGE', playerId, playerName })
+    localStorage.setItem('playerName', playerName)
+    mailbox.send({ type: 'JOIN_LOUNGE', playerId, playerName, mood })
     setJoined(true)
   }
 
   function handleNewGame() {
-    mailbox.send({ type: 'NEW_GAME' })
+    mailbox.send({ type: 'NEW_GAME', playerId })
   }
 
   if (!joined) {
@@ -47,7 +50,7 @@ export function Lounge({ mailbox, playerId, otherPlayers }: Props) {
         ))}
       </ul>
       <button onClick={handleNewGame}>New Game</button>
-      {/* TODO: mood picker — sends SET_MOOD */}
+      {/* TODO: mood picker — sends SET_PLAYER_INFO */}
     </div>
   )
 }

--- a/src/client/mail.ts
+++ b/src/client/mail.ts
@@ -1,31 +1,32 @@
 import * as t from "./types"
 
 export class Box {
-    constructor(
-        private webSocket: WebSocket,
-        private outbox: t.ToServerMessage[] = []
-    ) {
-        this.webSocket.onopen = () => {
-            for (let message of this.outbox) {
-                this.send(message)
-            }
+  constructor(
+    private webSocket: WebSocket,
+    private outbox: t.ToServerMessage[] = []
+  ) {
+    this.webSocket.onopen = () => {
+      for (let message of this.outbox) {
+        console.log("sending", message)
+        this.send(message)
+      }
 
-            this.outbox = []
-        }
+      this.outbox = []
     }
+  }
 
-    send(message: t.ToServerMessage) {
-        if (this.webSocket.readyState === WebSocket.OPEN) {
-            this.webSocket.send(JSON.stringify(message))
-        } else {
-            this.outbox.push(message)
-        }
+  send(message: t.ToServerMessage) {
+    if (this.webSocket.readyState === WebSocket.OPEN) {
+      this.webSocket.send(JSON.stringify(message))
+    } else {
+      this.outbox.push(message)
     }
+  }
 
-    listen(callback: (message: t.ToClientMessage) => void) {
-        this.webSocket.onmessage = (event) => {
-            const message = JSON.parse(event.data) as t.ToClientMessage
-            callback(message)
-        }
+  listen(callback: (message: t.ToClientMessage) => void) {
+    this.webSocket.onmessage = (event) => {
+      const message = JSON.parse(event.data) as t.ToClientMessage
+      callback(message)
     }
+  }
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -5,7 +5,7 @@ import * as t from '../types'
 
 export type View =
   | { type: 'LOUNGE' }
-  | { type: 'LOBBY', gameId: string, isReady: [t.PlayerId, boolean][] }
+  | { type: 'LOBBY', gameId: string, isReady: [t.PlayerId, boolean][], secsLeft?: number }
   | { type: 'GUESSES', gameId: string, hasGuessed: [t.PlayerId, boolean][], category: string, secsLeft: number, guess?: string }
   | { type: 'SCORES', gameId: string, scores: [t.PlayerId, number][], category: string }
 
@@ -16,6 +16,7 @@ export type State = {
   otherPlayers: [t.PlayerId, t.PlayerName, t.Mood][],
   playerId: string,
   playerName: string,
+  mood: t.Mood
 }
 
 export function initialState(): State {
@@ -23,13 +24,17 @@ export function initialState(): State {
   const websocketProtocol = document.location.protocol == 'http:' ? 'ws' : 'wss'
   const mailbox = new mail.Box(new WebSocket(`${websocketProtocol}://${window.location.host}/ws`))
 
-  // TODO: Check local storage for existing playerId and playerName
+  const playerId = localStorage.getItem('playerId') ?? crypto.randomUUID()
+  const playerName = localStorage.getItem('playerName') ?? ''
+  localStorage.setItem('playerId', playerId)
+
   return {
     audioPlayer,
     mailbox,
     view: { type: 'LOUNGE' },
     otherPlayers: [],
-    playerId: crypto.randomUUID(),
-    playerName: '',
+    playerId,
+    playerName,
+    mood: '😀'
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express'
 import http from 'http'
 import * as api from './server/api'
 import * as names from './server/names'
+import * as play from './server/play'
 import * as t from './server/types'
 
 import path from 'path';
@@ -33,6 +34,8 @@ api.addRest(
 api.addStatic(
     app,
 )
+
+play.startTicking(state, 100)
 
 const webServer = http.createServer(app)
 webServer.listen(8000, '0.0.0.0')

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -1,25 +1,36 @@
 import express from 'express'
 import expressWs from 'express-ws'
-import path  from 'path'
+import path from 'path'
 import * as ws from 'ws'
 import * as play from './play'
 import * as t from './types'
 
+const socketOwner = new Map<ws.WebSocket, t.PlayerId>()
+
 export function addWebsockets(state: t.State, app: express.Application) {
-    expressWs(app)
-    app.ws('/ws', (webSocket: ws.WebSocket, req: any) => {
-        webSocket.on('message', (data: object) => {
-            play.onClientMessage(state, data as t.ToServerMessage, webSocket)
-        })
+  const wsApp = expressWs(app).app
+  wsApp.ws('/ws', (webSocket: ws.WebSocket, req: any) => {
+    webSocket.on('message', (data: Buffer) => {
+      const message = JSON.parse(data.toString()) as t.ToServerMessage
+      const boundId = socketOwner.get(webSocket)
+      if (boundId === undefined) {
+        socketOwner.set(webSocket, message.playerId)
+      } else if (boundId !== message.playerId) {
+        console.warn('Rejected message: playerId mismatch', { expected: boundId, got: message.playerId })
+        return
+      }
+      play.onClientMessage(state, message, webSocket)
     })
+    webSocket.on('close', () => socketOwner.delete(webSocket))
+  })
 }
 
 export function addRest(app: express.Application) {
 }
 
 export function addStatic(app: express.Application) {
-    app.use(express.static(path.resolve('dist')))
-    app.get('*', (req, res) => {
-        res.sendFile(path.resolve('dist/index.html'))
-    })
+  app.use(express.static(path.resolve('dist')))
+  app.get('*', (req, res) => {
+    res.sendFile(path.resolve('dist/index.html'))
+  })
 }

--- a/src/server/play.ts
+++ b/src/server/play.ts
@@ -4,278 +4,268 @@ import * as t from './types'
 import * as util from './util'
 
 export function startTicking(
-    startingState: t.State,
-    tickMilliseconds: number,
+  startingState: t.State,
+  tickMilliseconds: number,
 ) {
-    const state = startingState
-    let timeSecs = util.nowSecs()
-    let deltaSecs = 0
+  const state = startingState
+  let timeSecs = util.nowSecs()
+  let deltaSecs = 0
 
-    const tick = () => {
-        const now = util.nowSecs()
-        deltaSecs = now - timeSecs
-        timeSecs = now
-        onTick(state, timeSecs, deltaSecs)
-    }
+  const tick = () => {
+    const now = util.nowSecs()
+    deltaSecs = now - timeSecs
+    timeSecs = now
+    onTick(state, timeSecs, deltaSecs)
+  }
 
-    setInterval(tick, tickMilliseconds);
+  setInterval(tick, tickMilliseconds);
 }
 
 function onTick(state: t.State, timeSecs: number, deltaSecs: number) {
-    for (let [gameId, game] of state.games) {
-        onTickGame(gameId, game, timeSecs, deltaSecs)
-    }
+  for (let [gameId, game] of state.games) {
+    onTickGame(gameId, game, timeSecs, deltaSecs)
+  }
+}
+
+function newGuessPhase(round: number, category: string): t.Phase {
+  return {
+    type: 'GUESSES',
+    round,
+    category,
+    secsLeft: config.GUESS_SECS,
+    guesses: new Map,
+  }
 }
 
 function onTickGame(gameId: t.GameId, game: t.Game, timeSecs: number, deltaSecs: number) {
-    const phase = game.phase
-    switch(phase.type) {
-        case 'LOBBY':
-            if (phase.secsLeft === undefined) {
-                break
-            }
+  const phase = game.phase
+  switch (phase.type) {
+    case 'LOBBY': {
+      if (phase.secsLeft === undefined) break
 
-            // We are counting down
-            phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
+      phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
 
-            if (phase.secsLeft === 0) {
-                // TODO: Choose category
-                const category = 'animals'
-
-                game.phase = {
-                    type: 'GUESSES',
-                    round: 0,
-                    category,
-                    secsLeft: config.GUESS_SECS,
-                    guesses: new Map,
-                }
-                game.broadcast(currentGameState(gameId, game))
-            }
-            break
-
-        case 'GUESSES':
-            phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
-
-            if (phase.secsLeft === 0) {
-                // TODO: Calculate scores
-                const scores = new Map<t.PlayerId, number>()
-
-                game.phase = {
-                    type: 'SCORES',
-                    round: 0,
-                    category: phase.category,
-                    secsLeft: config.SCORE_SECS,
-                    scores,
-                }
-                game.broadcast(currentGameState(gameId, game))
-            }
-            break
-
-        case 'SCORES':
-            phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
-
-            if (phase.secsLeft === 0) {
-                const round = phase.round + 1
-
-                // Game over
-                if (round === config.ROUNDS_PER_GAME) {
-                    game.phase = {
-                        type: 'LOBBY',
-                        secsLeft: undefined,
-                        isReady: new Set,
-                    }
-
-                // Next round
-                } else {
-                    // TODO: Choose category
-                    const category = 'animals'
-
-                    // TODO: Make a function so this is not duplicated above
-                    game.phase = {
-                        type: 'GUESSES',
-                        round,
-                        category,
-                        secsLeft: config.GUESS_SECS,
-                        guesses: new Map,
-                    }
-                }
-
-                game.broadcast(currentGameState(gameId, game))
-            }
-
-            break
+      if (phase.secsLeft === 0) {
+        // TODO: Choose category
+        const category = 'animals'
+        game.phase = newGuessPhase(0, category)
+        game.broadcast(currentGameState(gameId, game))
+      }
+      break
     }
+
+    case 'GUESSES': {
+      phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
+
+      if (phase.secsLeft === 0) {
+        // TODO: Calculate scores
+        const scores = new Map<t.PlayerId, number>()
+
+        game.phase = {
+          type: 'SCORES',
+          round: phase.round,
+          category: phase.category,
+          secsLeft: config.SCORE_SECS,
+          scores,
+        }
+        game.broadcast(currentGameState(gameId, game))
+      }
+      break
+    }
+
+    case 'SCORES': {
+      phase.secsLeft = Math.max(0, phase.secsLeft - deltaSecs)
+
+      if (phase.secsLeft === 0) {
+        const round = phase.round + 1
+
+        if (round === config.ROUNDS_PER_GAME) {
+          game.phase = { type: 'LOBBY', secsLeft: undefined, isReady: new Set }
+        } else {
+          // TODO: Choose category
+          const category = 'animals'
+          game.phase = newGuessPhase(round, category)
+        }
+
+        game.broadcast(currentGameState(gameId, game))
+      }
+      break
+    }
+  }
 }
 
 export function onClientMessage(state: t.State, message: t.ToServerMessage, webSocket: ws.WebSocket) {
-    switch(message.type) {
-        case 'JOIN_LOUNGE':
-            state.lounge.set(message.playerId, {
-                playerName: message.playerName,
-                mood: message.mood,
-                webSocket,
-            })
-            state.broadcastLoungeChange()
-            break
-
-        case 'SET_PLAYER_INFO':
-            if (message.gameId) {
-                const game = state.games.get(message.gameId)
-                // TODO: Log error
-                if (!game) {
-                    break
-                }
-
-                for (let info of game.players) {
-                    if (info.id === message.playerId) {
-                        info.mood = message.mood
-                        game.broadcast({
-                            type: 'MEMBER_CHANGE',
-                            gameId: message.gameId,
-                            allPlayers: game.players.map(info => [info.id, info.name, info.mood]),
-                        })
-                        break
-                    }
-                }
-
-            } else {
-                const loungeInfo = state.lounge.get(message.playerId)
-                if (!loungeInfo) {
-                    // TODO: Log error
-                    break
-                }
-                loungeInfo.playerName = message.playerName
-                loungeInfo.mood = message.mood
-            }
-
-            state.broadcastLoungeChange()
-            break
-
-        case 'NEW_GAME':
-            const loungeInfo = state.lounge.get(message.playerId)
-            if (!loungeInfo) {
-                // TODO: Log error
-                break
-            }
-
-            const gameId = state.nameChooser.choose(state.games.has)
-            const newGame = new t.Game
-            newGame.players.push({
-                id: message.playerId,
-                name: loungeInfo.playerName,
-                mood: loungeInfo.mood,
-                webSocket,
-                previousScoresAndGuesses: [],
-                currentGuess: undefined,
-            })
-
-            state.games.set(gameId, newGame)
-            newGame.broadcast(currentGameState(gameId, newGame))
-            state.broadcastLoungeChange()
-            break
-
-        case 'SUBSCRIBE_GAME':
-            const game = state.games.get(message.gameId)
-            if (!game) {
-                // TODO: Log error
-                break
-            }
-
-            const alreadyPlayer = game.players.find(playerInfo => playerInfo.id === message.playerId)
-            if (alreadyPlayer) {
-                alreadyPlayer.webSocket = webSocket
-            } else {
-                game.players.push({
-                    id: message.playerId,
-                    name: message.playerName,
-                    // TODO: Should we log error?
-                    mood: state.lounge.get(message.playerId)?.mood || '😀',
-                    webSocket,
-                    previousScoresAndGuesses: [],
-                    currentGuess: undefined,
-                })
-            }
-
-            game.unicast(
-                message.playerId,
-                currentGameState(message.gameId, game)
-            )
-
-            game.broadcast({
-                type: 'MEMBER_CHANGE',
-                gameId: message.gameId,
-                allPlayers: game.players.map(info => [info.id, info.name, info.mood]),
-            })
-
-            // In case they were in the lounge
-            state.lounge.delete(message.playerId)
-            state.broadcastLoungeChange()
-            break
-
-        case 'READY':
-            const lobbyGame = state.games.get(message.gameId)
-            if (!lobbyGame || lobbyGame.phase.type !== 'LOBBY') {
-                // TODO: Log error
-                break
-            }
-
-            if (message.isReady) lobbyGame.phase.isReady.add(message.playerId)
-            else                 lobbyGame.phase.isReady.delete(message.playerId)
-
-            // Send ready updates first
-            lobbyGame.broadcast(currentGameState(message.gameId, lobbyGame))
-
-            const livePlayerIds = lobbyGame.players
-                .filter(info => info.webSocket.readyState === ws.WebSocket.OPEN)
-                .map(info => info.id)
-            if (livePlayerIds.every(id => lobbyGame.phase.isReady.has(id))) {
-                lobbyGame.phase.secsLeft = config.LOBBY_COUNTDOWN_SECS
-                lobbyGame.broadcast(currentGameState(message.gameId, lobbyGame))
-            }
-
-            break
-
-        case 'GUESS':
-            const scoreGame = state.games.get(message.gameId)
-            if (!scoreGame || scoreGame.phase.type !== 'GUESSES') {
-                // TODO: Log error
-                break
-            }
-            scoreGame.phase.guesses.set(message.playerId, message.guess)
-            scoreGame.broadcast(currentGameState(message.gameId, scoreGame))
-            break
+  switch (message.type) {
+    case 'JOIN_LOUNGE': {
+      state.lounge.set(message.playerId, {
+        name: message.playerName,
+        mood: message.mood,
+        webSocket,
+      })
+      state.broadcastLoungeChange()
+      break
     }
+
+    case 'SET_PLAYER_INFO': {
+      if (message.gameId) {
+        const game = state.games.get(message.gameId)
+        if (!game) {
+          console.warn('SET_PLAYER_INFO: game not found', message.gameId)
+          break
+        }
+
+        for (const info of game.players) {
+          if (info.id === message.playerId) {
+            info.mood = message.mood
+            game.broadcast(game.memberChangeMessage(message.gameId))
+            break
+          }
+        }
+
+      } else {
+        const loungeInfo = state.lounge.get(message.playerId)
+        if (!loungeInfo) {
+          console.warn('SET_PLAYER_INFO: player not in lounge', message.playerId)
+          break
+        }
+        loungeInfo.name = message.playerName
+        loungeInfo.mood = message.mood
+        state.broadcastLoungeChange()
+      }
+
+      break
+    }
+
+    case 'NEW_GAME': {
+      const loungeInfo = state.lounge.get(message.playerId)
+      if (!loungeInfo) {
+        console.warn('NEW_GAME: player not in lounge', message.playerId)
+        break
+      }
+
+      const gameId = state.nameChooser.choose(id => state.games.has(id))
+      const newGame = new t.Game
+      newGame.players.push({
+        id: message.playerId,
+        name: loungeInfo.name,
+        mood: loungeInfo.mood,
+        webSocket,
+        previousScoresAndGuesses: [],
+        currentGuess: undefined,
+      })
+
+      state.games.set(gameId, newGame)
+      state.broadcastLoungeChange()
+      break
+    }
+
+    case 'SUBSCRIBE_GAME': {
+      const game = state.games.get(message.gameId)
+      if (!game) {
+        console.warn('SUBSCRIBE_GAME: game not found', message.gameId)
+        break
+      }
+
+      const alreadyPlayer = game.players.find(playerInfo => playerInfo.id === message.playerId)
+      if (alreadyPlayer) {
+        alreadyPlayer.webSocket = webSocket
+      } else {
+        game.players.push({
+          id: message.playerId,
+          name: message.playerName,
+          mood: state.lounge.get(message.playerId)?.mood || '😀',
+          webSocket,
+          previousScoresAndGuesses: [],
+          currentGuess: undefined,
+        })
+      }
+
+      game.unicast(message.playerId, currentGameState(message.gameId, game))
+      game.broadcast(game.memberChangeMessage(message.gameId))
+
+      // In case they were in the lounge
+      state.lounge.delete(message.playerId)
+      state.broadcastLoungeChange()
+      break
+    }
+
+    case 'READY': {
+      const game = state.games.get(message.gameId)
+      if (!game || game.phase.type !== 'LOBBY') {
+        console.warn('READY: game not found or not in LOBBY phase', message.gameId)
+        break
+      }
+
+      const lobby = game.phase
+
+      if (message.isReady) lobby.isReady.add(message.playerId)
+      else lobby.isReady.delete(message.playerId)
+
+      game.broadcast(currentGameState(message.gameId, game))
+
+      const livePlayerIds = game.players
+        .filter(info => info.webSocket.readyState === ws.WebSocket.OPEN)
+        .map(info => info.id)
+      const allReady = livePlayerIds.length >= 2 && livePlayerIds.every(id => lobby.isReady.has(id))
+      if (allReady) {
+        lobby.secsLeft = config.LOBBY_COUNTDOWN_SECS
+        game.broadcast(currentGameState(message.gameId, game))
+      } else if (lobby.secsLeft !== undefined) {
+        lobby.secsLeft = undefined
+        game.broadcast(currentGameState(message.gameId, game))
+      }
+
+      break
+    }
+
+    case 'GUESS': {
+      const game = state.games.get(message.gameId)
+      if (!game || game.phase.type !== 'GUESSES') {
+        console.warn('GUESS: game not found or not in GUESSES phase', message.gameId)
+        break
+      }
+      game.phase.guesses.set(message.playerId, message.guess)
+      game.broadcast(currentGameState(message.gameId, game))
+      break
+    }
+  }
 }
 
 function currentGameState(gameId: t.GameId, game: t.Game): t.ToClientMessage {
-    switch(game.phase.type) {
-        case 'LOBBY':
-            return game.phase.secsLeft === undefined
-                ? {
-                    type: 'LOBBY_STATE',
-                    gameId,
-                    isReady: game.players.map(info => [info.id, game.phase.isReady.has(info.id)])
-                }
-                : {
-                    type: 'LOBBY_COUNTDOWN',
-                    gameId,
-                    secsLeft: game.phase.secsLeft
-                }
-        case 'GUESSES':
-            return {
-                type: 'GUESS_STATE',
-                gameId,
-                category: game.phase.category,
-                hasGuessed: game.players.map(info => [info.id, game.phase.guesses.has(info.id)]),
-                secsLeft: game.phase.secsLeft
-            }
-        case 'SCORES':
-            return {
-                type: 'SCORE_STATE',
-                gameId,
-                category: game.phase.category,
-                playerScores: [...game.phase.scores.entries()],
-                secsLeft: game.phase.secsLeft,
-            }
+  switch (game.phase.type) {
+    case 'LOBBY': {
+      const lobby = game.phase
+      return lobby.secsLeft === undefined
+        ? {
+          type: 'LOBBY_STATE',
+          gameId,
+          isReady: game.players.map(info => [info.id, lobby.isReady.has(info.id)])
+        }
+        : {
+          type: 'LOBBY_COUNTDOWN',
+          gameId,
+          secsLeft: lobby.secsLeft
+        }
     }
+    case 'GUESSES': {
+      const phase = game.phase
+      return {
+        type: 'GUESS_STATE',
+        gameId,
+        category: phase.category,
+        hasGuessed: game.players.map(info => [info.id, phase.guesses.has(info.id)]),
+        secsLeft: phase.secsLeft
+      }
+    }
+    case 'SCORES': {
+      const phase = game.phase
+      return {
+        type: 'SCORE_STATE',
+        gameId,
+        category: phase.category,
+        playerScores: [...phase.scores.entries()],
+        secsLeft: phase.secsLeft,
+      }
+    }
+  }
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -30,10 +30,10 @@ export class Game {
     unicast(playerId: t.PlayerId, message: t.ToClientMessage) {
         const player = this.players.find(info => info.id === playerId)
         if (!player) {
-            // TODO:
+            console.warn('unicast: player not found', playerId)
             return
         } else if (player.webSocket.readyState !== ws.WebSocket.OPEN) {
-            // TODO:
+            console.warn('unicast: WebSocket not open', playerId)
             return
         }
 
@@ -45,10 +45,18 @@ export class Game {
             this.unicast(player.id, message)
         }
     }
+
+    memberChangeMessage(gameId: t.GameId): t.ToClientMessage {
+        return {
+            type: 'MEMBER_CHANGE',
+            gameId,
+            allPlayers: this.players.map(info => [info.id, info.name, info.mood]),
+        }
+    }
 }
 
 export interface LoungeInfo {
-    playerName: t.PlayerName;
+    name: t.PlayerName;
     mood: t.Mood;
     webSocket: ws.WebSocket;
 }
@@ -67,7 +75,7 @@ export class State {
     broadcastToLounge(message: t.ToClientMessage) {
         for (let loungeInfo of this.lounge.values()) {
             if (loungeInfo.webSocket.readyState !== ws.WebSocket.OPEN) {
-                // TODO:
+                console.warn('broadcastToLounge: stale WebSocket, skipping')
                 continue
             }
 
@@ -79,7 +87,7 @@ export class State {
         this.broadcastToLounge({
             type: 'MEMBER_CHANGE',
             gameId: undefined,
-            allPlayers: [...this.lounge.entries()].map(([playerId, info]) => [playerId, info.playerName, info.mood])
+            allPlayers: [...this.lounge.entries()].map(([playerId, info]) => [playerId, info.name, info.mood])
         })
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type ToServerMessage =
   | { type: 'JOIN_LOUNGE', playerId: PlayerId, playerName: PlayerName, mood: Mood }
   | { type: 'SET_PLAYER_INFO', gameId?: GameId, playerId: PlayerId, playerName: PlayerName, mood: Mood }
   | { type: 'NEW_GAME', playerId: PlayerId }
-  | { type: 'SUBSCRIBE_GAME', gameId: GameId, playerId: PlayerId, playerName: string, mood: Mood }
+  | { type: 'SUBSCRIBE_GAME', gameId: GameId, playerId: PlayerId, playerName: PlayerName, mood: Mood }
   | { type: 'READY', gameId: GameId, playerId: PlayerId, isReady: boolean }
   | { type: 'GUESS', gameId: GameId, playerId: PlayerId, guess: string }
 

--- a/todos/agent/README.md
+++ b/todos/agent/README.md
@@ -1,0 +1,24 @@
+# Agent-Resolvable Todos
+
+Items Claude can fix autonomously — deterministic correct answers, no product
+judgment required. Worked via `/workflows:work`.
+
+## From 2026-02-18 Codebase Review (all resolved)
+
+| # | Finding | Status |
+|---|---------|--------|
+| 003 | WebSocket messages not parsed (`JSON.parse` missing) | done |
+| 004 | Tick loop never started (`startTicking` not called) | done |
+| 006 | `Map.has` unbound method reference | done |
+| 007 | Lobby countdown not wired to client | done |
+| 009 | `MEMBER_CHANGE` clobbers context (ignores `gameId`) | done |
+| 010 | `playerName` not synced (localStorage persistence) | done |
+| 011 | Switch-case shared scope | done |
+| 012 | Unnecessary lounge broadcast scoping | done |
+| 014 | `playerName` vs `name` inconsistency | done |
+| 017 | Missing error logging on guard clauses | done |
+| 018 | Single player can start game (min-2 guard) | done |
+| 019 | Player impersonation (playerId bound to socket) | done |
+| 020 | Round counter hardcoded to zero | done |
+
+Detailed todo files: `.claude/todos/`

--- a/todos/resolved/003-pending-p1-websocket-no-parse-or-validation.md
+++ b/todos/resolved/003-pending-p1-websocket-no-parse-or-validation.md
@@ -1,0 +1,48 @@
+---
+status: done
+priority: p1
+issue_id: "003"
+tags: [security, server]
+dependencies: []
+---
+
+# WebSocket Messages Not Parsed or Validated
+
+## Problem Statement
+
+The server casts raw WebSocket `data` directly to `ToServerMessage` without `JSON.parse()` or any validation. The `data` parameter is actually a `Buffer` at runtime, not a parsed object. This will cause runtime errors or silent corruption.
+
+## Findings
+
+- `src/server/api.ts:11-12` -- `data` typed as `object` but is actually `Buffer`; cast with `as t.ToServerMessage` without parsing
+- `src/client/mail.ts:27` -- client side does `JSON.parse(event.data) as t.ToClientMessage` (at least parses, but no validation)
+- No `default` case in `onClientMessage` switch -- unknown message types silently ignored
+- Player impersonation possible: `playerId` is client-supplied and never verified against the WebSocket connection
+
+## Proposed Solutions
+
+### Option 1: Parse + Basic Type Check
+
+**Approach:** `JSON.parse(data.toString())`, then verify `message.type` is a known value before processing. No external dependency needed.
+
+**Pros:**
+- Fixes the crash bug immediately
+- Minimal code
+
+**Cons:**
+- Doesn't validate field types within each message variant
+
+**Effort:** 30 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/api.ts:11-12` -- add JSON.parse and validation
+- `src/server/play.ts:110` -- add default case to switch
+
+## Acceptance Criteria
+
+- [ ] WebSocket data is JSON.parsed before processing
+- [ ] Invalid messages are rejected gracefully (not crash)
+- [ ] Unknown message types are logged

--- a/todos/resolved/004-pending-p1-tick-loop-never-started.md
+++ b/todos/resolved/004-pending-p1-tick-loop-never-started.md
@@ -1,0 +1,37 @@
+---
+status: done
+priority: p1
+issue_id: "004"
+tags: [server, core-mechanics]
+dependencies: []
+---
+
+# Tick Loop Never Started -- Game Phases Won't Advance
+
+## Problem Statement
+
+`startTicking()` is exported from `src/server/play.ts` but never called anywhere. The tick loop is responsible for advancing game phases (counting down timers, transitioning LOBBY -> GUESSES -> SCORES -> next round). Without it, games will get stuck after the lobby countdown starts.
+
+## Findings
+
+- `src/server/play.ts:6-22` -- `startTicking` exported but not imported/called
+- `src/server.ts` -- imports `api` and `names` but not `play`
+- The entire phase timer system (lobby countdown, guess timer, score timer) depends on the tick loop
+
+## Proposed Solutions
+
+### Option 1: Call startTicking in server.ts
+
+**Approach:** Import `play` in `server.ts` and call `play.startTicking(state, 100)` after setup.
+
+**Effort:** 5 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server.ts` -- add import and call to `startTicking`
+
+## Acceptance Criteria
+
+- [ ] Game timers count down and phases advance automatically

--- a/todos/resolved/006-pending-p1-map-has-unbound.md
+++ b/todos/resolved/006-pending-p1-map-has-unbound.md
@@ -1,0 +1,36 @@
+---
+status: done
+priority: p1
+issue_id: "006"
+tags: [bug, server]
+dependencies: []
+---
+
+# Map.has Passed Without Binding -- Runtime Crash
+
+## Problem Statement
+
+`state.games.has` is passed as a bare function reference, losing its `this` binding. This will throw `TypeError: Method Map.prototype.has called on incompatible receiver` when anyone creates a game.
+
+## Findings
+
+- `src/server/play.ts:161` -- `state.nameChooser.choose(state.games.has)`
+- `src/server/names.ts:20-24` -- `choose()` calls `isDuplicate(name)` which invokes the unbound `has`
+
+## Proposed Solutions
+
+### Option 1: Arrow function wrapper
+
+**Approach:** `state.nameChooser.choose((id) => state.games.has(id))`
+
+**Effort:** 1 minute
+
+**Risk:** None
+
+## Affected files
+
+- `src/server/play.ts:161` -- fix the binding
+
+## Acceptance Criteria
+
+- [ ] Game creation doesn't crash

--- a/todos/resolved/007-pending-p1-lobby-countdown-invisible.md
+++ b/todos/resolved/007-pending-p1-lobby-countdown-invisible.md
@@ -1,0 +1,39 @@
+---
+status: done
+priority: p1
+issue_id: "007"
+tags: [ui, game-flow]
+dependencies: []
+---
+
+# Lobby Countdown Invisible to Players
+
+## Problem Statement
+
+When all players ready up, the server sends `LOBBY_COUNTDOWN` with `secsLeft`. The client reducer returns `state` unchanged with a `// TODO: start countdown animation`. Players see no visual feedback that the game is about to start -- the view suddenly jumps from Lobby to Guesses.
+
+## Findings
+
+- `src/client.tsx:26-28` -- LOBBY_COUNTDOWN handler is a no-op
+- `src/server/play.ts:232-234` -- server correctly sends countdown
+- `config.LOBBY_COUNTDOWN_SECS = 3` -- only 3 seconds, but still jarring with zero feedback
+
+## Proposed Solutions
+
+### Option 1: Add secsLeft to Lobby view
+
+**Approach:** Add optional `secsLeft?: number` to the LOBBY View type. When LOBBY_COUNTDOWN arrives, update the view with `secsLeft`. Render it in the Lobby component as a countdown overlay.
+
+**Effort:** 30 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/client/types.ts:8` -- add `secsLeft?: number` to LOBBY view
+- `src/client.tsx:26-28` -- update state with countdown
+- `src/client/Lobby.tsx` -- render countdown when secsLeft is present
+
+## Acceptance Criteria
+
+- [ ] Players see a countdown (3, 2, 1) before the game starts

--- a/todos/resolved/009-pending-p2-member-change-clobbers-context.md
+++ b/todos/resolved/009-pending-p2-member-change-clobbers-context.md
@@ -1,0 +1,44 @@
+---
+status: done
+priority: p2
+issue_id: "009"
+tags: [bug, client, naming]
+dependencies: []
+---
+
+# MEMBER_CHANGE Ignores gameId -- Lounge/Game Lists Clobber Each Other
+
+## Problem Statement
+
+`MEMBER_CHANGE` is used for both lounge and game membership, distinguished by `gameId` being undefined vs present. But the client reducer ignores `gameId` and blindly overwrites `otherPlayers`. A lounge change while in a game (or vice versa) will silently replace the player list.
+
+Additionally, `otherPlayers` is misleading -- it contains ALL players including the current user.
+
+## Findings
+
+- `src/client.tsx:14-15` -- ignores `message.gameId`, always overwrites
+- `src/server/types.ts:78-84` -- lounge sends `MEMBER_CHANGE` with `gameId: undefined`
+- The `LOUNGE` message type exists in `src/types.ts:15` but server never sends it
+- `otherPlayers` name is inaccurate -- includes current player
+
+## Proposed Solutions
+
+### Option 1: Separate LOUNGE and MEMBER_CHANGE
+
+**Approach:** Use the existing `LOUNGE` message type for lounge broadcasts. Make `MEMBER_CHANGE.gameId` required. Client reducer filters by context.
+
+**Effort:** 1 hour
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/types.ts:78-84` -- send LOUNGE instead of MEMBER_CHANGE for lounge
+- `src/types.ts:16` -- make MEMBER_CHANGE.gameId required
+- `src/client.tsx:14-15` -- handle LOUNGE and MEMBER_CHANGE separately
+- Consider renaming `otherPlayers` to `allPlayers`
+
+## Acceptance Criteria
+
+- [ ] Lounge updates don't clobber game player lists
+- [ ] Game updates don't clobber lounge player lists

--- a/todos/resolved/010-pending-p2-playername-not-synced.md
+++ b/todos/resolved/010-pending-p2-playername-not-synced.md
@@ -1,0 +1,40 @@
+---
+status: done
+priority: p2
+issue_id: "010"
+tags: [client, state-management]
+dependencies: []
+---
+
+# Player Name Only in Local State -- Not Persisted or Synced
+
+## Problem Statement
+
+The player's name is captured in `Lounge` component local state (`useState`), sent to the server via `JOIN_LOUNGE`, but never stored in the app-level `State`. `state.playerName` stays as `''` forever. Additionally, there's no localStorage persistence -- every page refresh generates a new identity.
+
+## Findings
+
+- `src/client/types.ts:27` -- `// TODO: Check local storage for existing playerId and playerName`
+- `src/client/types.ts:18,34` -- `state.playerName` initialized to `''`, never updated
+- `src/client/Lounge.tsx:13` -- name lives in local `useState`, lost on view change
+- `src/client.tsx:37` -- `onMessage` reducer has no case that updates playerName
+
+## Proposed Solutions
+
+### Option 1: Persist to localStorage + update state
+
+**Approach:** On join, save playerId and playerName to localStorage. On init, check localStorage first. Update app state when name is set.
+
+**Effort:** 30 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/client/types.ts:22-37` -- check localStorage in initialState
+- `src/client.tsx` -- add mechanism to update playerName in state
+
+## Acceptance Criteria
+
+- [ ] Page refresh preserves player identity
+- [ ] `state.playerName` reflects the actual player name

--- a/todos/resolved/011-pending-p2-switch-case-scoping.md
+++ b/todos/resolved/011-pending-p2-switch-case-scoping.md
@@ -1,0 +1,40 @@
+---
+status: done
+priority: p2
+issue_id: "011"
+tags: [code-quality, server]
+dependencies: []
+---
+
+# Switch Cases Need Block Scope + Duplicated Phase Init
+
+## Problem Statement
+
+`onClientMessage` switch cases share scope, forcing unique variable names (`game`, `lobbyGame`, `scoreGame`). The GUESSES phase initialization code is also duplicated in two places in `onTickGame` (lines 45-51 and 92-100, with a TODO acknowledging it).
+
+## Findings
+
+- `src/server/play.ts:111-248` -- switch cases without `{}` blocks
+- `src/server/play.ts:45-51, 92-100` -- `// TODO: Make a function so this is not duplicated above`
+- MEMBER_CHANGE broadcast constructed manually in 3 places (play.ts:132-136, 203-207, types.ts:78-84)
+
+## Proposed Solutions
+
+### Option 1: Add block braces + extract helpers
+
+**Approach:** Wrap each case in `{}`. Extract `newGuessPhase(round, category)` helper. Add `Game.memberChangeMessage(gameId)` method.
+
+**Effort:** 30 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/play.ts` -- block scopes, extract helper
+- `src/server/types.ts` -- add memberChangeMessage to Game class
+
+## Acceptance Criteria
+
+- [ ] Each switch case has its own block scope
+- [ ] GUESSES phase init not duplicated
+- [ ] MEMBER_CHANGE construction not duplicated

--- a/todos/resolved/012-pending-p2-unnecessary-lounge-broadcast.md
+++ b/todos/resolved/012-pending-p2-unnecessary-lounge-broadcast.md
@@ -1,0 +1,36 @@
+---
+status: done
+priority: p2
+issue_id: "012"
+tags: [bug, server]
+dependencies: []
+---
+
+# SET_PLAYER_INFO Always Broadcasts Lounge Change, Even for In-Game Updates
+
+## Problem Statement
+
+When `SET_PLAYER_INFO` is handled with a `gameId` (player is in a game), the code broadcasts to the game, then falls through and calls `state.broadcastLoungeChange()` even though no lounge data changed. The `break` on line 137 breaks the inner `for` loop, not the `case`.
+
+## Findings
+
+- `src/server/play.ts:121-152` -- `broadcastLoungeChange()` on line 151 runs unconditionally
+- The `break` on line 137 exits the `for` loop, not the switch case
+
+## Proposed Solutions
+
+### Option 1: Move broadcastLoungeChange into else branch
+
+**Approach:** Only call `broadcastLoungeChange()` when the lounge actually changed (the `else` branch).
+
+**Effort:** 5 minutes
+
+**Risk:** None
+
+## Affected files
+
+- `src/server/play.ts:151` -- move into else branch or add early return
+
+## Acceptance Criteria
+
+- [ ] In-game mood changes don't trigger unnecessary lounge broadcasts

--- a/todos/resolved/014-pending-p2-playerName-vs-name-inconsistency.md
+++ b/todos/resolved/014-pending-p2-playerName-vs-name-inconsistency.md
@@ -1,0 +1,41 @@
+---
+status: done
+priority: p2
+issue_id: "014"
+tags: [naming, consistency]
+dependencies: []
+---
+
+# playerName vs name Inconsistency Across Boundaries
+
+## Problem Statement
+
+Server's `PlayerInfo` uses `name`, `LoungeInfo` uses `playerName`, wire messages use `playerName`. This causes translation code at every boundary and will trip up anyone assuming field names match.
+
+## Findings
+
+- `src/server/types.ts:8` -- `PlayerInfo.name`
+- `src/server/types.ts:51` -- `LoungeInfo.playerName`
+- `src/types.ts:7-10` -- wire messages use `playerName`
+- `src/server/play.ts:165,189` -- manual translation `name: loungeInfo.playerName`
+- `src/types.ts:10` -- SUBSCRIBE_GAME uses `playerName: string` (raw string, not `PlayerName` alias)
+
+## Proposed Solutions
+
+### Option 1: Standardize on one name
+
+**Approach:** Pick `playerName` everywhere (more specific in context with gameId/playerId). Update `PlayerInfo.name` to `PlayerInfo.playerName`.
+
+**Effort:** 30 minutes
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/types.ts:8` -- rename field
+- `src/server/play.ts` -- update all references
+- `src/types.ts:10` -- use `PlayerName` type alias
+
+## Acceptance Criteria
+
+- [ ] Single consistent name used across all boundaries

--- a/todos/resolved/017-pending-p2-add-error-logging.md
+++ b/todos/resolved/017-pending-p2-add-error-logging.md
@@ -1,0 +1,39 @@
+---
+status: done
+priority: p2
+issue_id: "017"
+tags: [debugging, server]
+dependencies: []
+---
+
+# Add console.warn to 9 Silent Error Guard Clauses
+
+## Problem Statement
+
+There are 9 locations across server code where errors are silently swallowed with empty `// TODO:` or `// TODO: Log error` comments. Debugging bad client messages or race conditions is nearly impossible without any logging.
+
+## Findings
+
+- `src/server/types.ts:33` -- unicast: player not found (empty TODO)
+- `src/server/types.ts:36` -- unicast: WebSocket not open (empty TODO)
+- `src/server/types.ts:70` -- broadcastToLounge: stale WebSocket (empty TODO)
+- `src/server/play.ts:124` -- SET_PLAYER_INFO: game not found
+- `src/server/play.ts:144` -- SET_PLAYER_INFO: loungeInfo not found
+- `src/server/play.ts:157` -- NEW_GAME: loungeInfo not found
+- `src/server/play.ts:179` -- SUBSCRIBE_GAME: game not found
+- `src/server/play.ts:217` -- READY: game not found or wrong phase
+- `src/server/play.ts:242` -- GUESS: game not found or wrong phase
+
+## Proposed Solutions
+
+### Option 1: Single pass adding console.warn
+
+**Approach:** Replace each empty TODO with a `console.warn('context:', relevantIds)` call. ~20 minutes of work.
+
+**Effort:** 20 minutes
+
+**Risk:** None
+
+## Acceptance Criteria
+
+- [ ] All 9 locations log a warning with useful context

--- a/todos/resolved/018-pending-p2-single-player-starts-game.md
+++ b/todos/resolved/018-pending-p2-single-player-starts-game.md
@@ -1,0 +1,39 @@
+---
+status: done
+priority: p2
+issue_id: "018"
+tags: [game-logic, server]
+dependencies: []
+---
+
+# Single Player Can Start Countdown + Countdown Never Cancels
+
+## Problem Statement
+
+Two related lobby countdown bugs:
+1. A single player clicking "Ready" starts the countdown because `Array.every()` on a one-element array returns true. A Schelling Point game with one person is not a game.
+2. Once the countdown starts, un-readying doesn't cancel it. `lobby.secsLeft` stays set and the game starts anyway.
+
+## Findings
+
+- `src/server/play.ts:229-235` -- no minimum player count check
+- `src/server/play.ts:214-237` -- no countdown cancellation when a player un-readies
+
+## Proposed Solutions
+
+### Option 1: Min player count + cancel on un-ready
+
+**Approach:** Add `livePlayerIds.length >= 2` check. After ready set update, if `lobby.secsLeft !== undefined` and not all ready, reset `lobby.secsLeft = undefined`.
+
+**Effort:** Small
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/play.ts:229-237` -- add both guards
+
+## Acceptance Criteria
+
+- [ ] Game requires at least 2 players to start countdown
+- [ ] Un-readying during countdown cancels it

--- a/todos/resolved/019-pending-p2-player-impersonation.md
+++ b/todos/resolved/019-pending-p2-player-impersonation.md
@@ -1,0 +1,39 @@
+---
+status: done
+priority: p2
+issue_id: "019"
+tags: [security, server]
+dependencies: []
+---
+
+# Player Impersonation -- playerId is Client-Supplied and Untrusted
+
+## Problem Statement
+
+The client generates its own `playerId` via `crypto.randomUUID()` and sends it in every message. The server never validates that a WebSocket connection "owns" that playerId. Any client can send messages with another player's ID to ready/unready them, submit guesses on their behalf, or hijack their WebSocket reference.
+
+## Findings
+
+- `src/client/types.ts:33` -- client generates its own ID
+- `src/server/play.ts:110-248` -- server trusts whatever playerId arrives
+- No WebSocket-to-player binding exists
+
+## Proposed Solutions
+
+### Option 1: Bind playerId to WebSocket on first message
+
+**Approach:** On JOIN_LOUNGE, record a `Map<WebSocket, PlayerId>` binding. Reject subsequent messages where `message.playerId` doesn't match the bound ID for that socket.
+
+**Effort:** 1 hour
+
+**Risk:** Low
+
+## Affected files
+
+- `src/server/api.ts` -- track binding
+- `src/server/play.ts` -- validate playerId against bound socket
+
+## Acceptance Criteria
+
+- [ ] A WebSocket can only act as one player
+- [ ] Messages with mismatched playerId are rejected

--- a/todos/resolved/020-pending-p1-round-counter-hardcoded-zero.md
+++ b/todos/resolved/020-pending-p1-round-counter-hardcoded-zero.md
@@ -1,0 +1,37 @@
+---
+status: done
+priority: p1
+issue_id: "020"
+tags: [game-logic, server, bug]
+dependencies: []
+---
+
+# Round Counter Hardcoded to 0 in SCORES Phase -- Game Never Ends
+
+## Problem Statement
+
+When transitioning from GUESSES to SCORES phase, `round` is hardcoded to `0` instead of carrying forward `phase.round`. This means the game-over check (`phase.round + 1 === config.ROUNDS_PER_GAME`) always evaluates to `1 === 10`, which is false. The game loops infinitely past round 10.
+
+## Findings
+
+- `src/server/play.ts:65` -- `round: 0` should be `round: phase.round`
+- `src/server/play.ts:81` -- game-over check uses `phase.round + 1 === config.ROUNDS_PER_GAME`, always false when round is 0
+
+## Proposed Solutions
+
+### Option 1: One-line fix
+
+**Approach:** Change `round: 0` to `round: phase.round` on line 65.
+
+**Effort:** 1 minute
+
+**Risk:** None
+
+## Affected files
+
+- `src/server/play.ts:65` -- fix round assignment
+
+## Acceptance Criteria
+
+- [ ] SCORES phase carries correct round number from GUESSES phase
+- [ ] Game ends after 10 rounds

--- a/todos/user/README.md
+++ b/todos/user/README.md
@@ -1,0 +1,19 @@
+# Human-Needed Todos
+
+Items requiring product decisions, UX judgment, or architecture trade-offs.
+Each is linked to a GitHub issue on the
+[project board](https://github.com/users/thrialectics/projects/1/views/1).
+
+## From 2026-02-18 Codebase Review
+
+| # | Finding | Issue | Status |
+|---|---------|-------|--------|
+| 001 | Scoring algorithm (formula, normalization, no-answer) | [#27](https://github.com/hartphoenix/schelling-points/issues/27) | backlog |
+| 002 | Category list and selection method | [#28](https://github.com/hartphoenix/schelling-points/issues/28) | backlog |
+| 005 | Game creation flow (auto-subscribe, discovery) | [#29](https://github.com/hartphoenix/schelling-points/issues/29) | backlog |
+| 008 | Scores view UX (guess reveal, timer, game-over) | [#30](https://github.com/hartphoenix/schelling-points/issues/30) | backlog |
+| 013 | Disconnect handling (grace period, reconnection) | [#31](https://github.com/hartphoenix/schelling-points/issues/31) | backlog |
+| 015 | Dead code triage (scaffolding vs truly dead) | [#32](https://github.com/hartphoenix/schelling-points/issues/32) | backlog |
+| 016 | Tuple vs object wire format | [#33](https://github.com/hartphoenix/schelling-points/issues/33) | backlog |
+
+Detailed todo files: `.claude/todos/`


### PR DESCRIPTION
## Summary

- **Server**: Parse WebSocket data as JSON, bind sockets to player IDs, start the tick loop, fix `Map.has` losing `this`, derive round counter from phase state, add block scoping to switch cases, require 2+ players for countdown, cancel countdown on unready, normalize naming
- **Client**: Filter `MEMBER_CHANGE` by gameId, render lobby countdown, persist player identity in localStorage, include playerId in outgoing messages, fix type consistency
- **Housekeeping**: Add `bun.lock`, ignore `.claude/`, include review triage docs in `todos/`

All fixes are deterministic — single correct answer derivable from code context or language rules. Product/design decisions (scoring, categories, UX flows, disconnect handling) were filed as separate GitHub issues (#27–#33).

## Test plan

- [ ] `bun run build` compiles without errors
- [ ] Two-player lobby flow: join → ready → countdown → guess → scores → next round
- [ ] Unreadying during countdown cancels it
- [ ] Refreshing browser preserves player identity (localStorage)
- [ ] Single player cannot trigger countdown alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)