### PR TITLE
Add 53 new category prompts

### DIFF
--- a/src/server/categories.json
+++ b/src/server/categories.json
@@ -603,5 +603,271 @@
     "id": 121,
     "prompt": "a name",
     "difficulty": "hard"
+  },
+  {
+    "id": 122,
+    "prompt": "US state",
+    "difficulty": "medium"
+  },
+  {
+    "id": 123,
+    "prompt": "meal of the day",
+    "difficulty": "easy"
+  },
+  {
+    "id": 124,
+    "prompt": "type of weather",
+    "difficulty": "easy"
+  },
+  {
+    "id": 125,
+    "prompt": "common pet",
+    "difficulty": "easy"
+  },
+  {
+    "id": 126,
+    "prompt": "thing in a junk drawer",
+    "difficulty": "medium"
+  },
+  {
+    "id": 127,
+    "prompt": "most recognizable smell",
+    "difficulty": "medium"
+  },
+  {
+    "id": 128,
+    "prompt": "thing you google at 2am",
+    "difficulty": "hard"
+  },
+  {
+    "id": 129,
+    "prompt": "thing you ask claude at 2am",
+    "difficulty": "hard"
+  },
+  {
+    "id": 130,
+    "prompt": "excuse to leave a party",
+    "difficulty": "hard"
+  },
+  {
+    "id": 131,
+    "prompt": "app you check in the morning",
+    "difficulty": "medium"
+  },
+  {
+    "id": 132,
+    "prompt": "thing everyone owns but doesn't use",
+    "difficulty": "medium"
+  },
+  {
+    "id": 133,
+    "prompt": "first thing you'd save in a fire",
+    "difficulty": "medium"
+  },
+  {
+    "id": 134,
+    "prompt": "thing people are secretly competitive about",
+    "difficulty": "medium"
+  },
+  {
+    "id": 135,
+    "prompt": "green flag on first date",
+    "difficulty": "medium"
+  },
+  {
+    "id": 136,
+    "prompt": "red flag on first date",
+    "difficulty": "medium"
+  },
+  {
+    "id": 137,
+    "prompt": "unspoken rule of living with roommates",
+    "difficulty": "medium"
+  },
+  {                                                                             
+    "id": 138,                                                                
+    "prompt": "thing you do when the wifi goes out",                          
+    "difficulty": "medium"                                                  
+  },                                                                          
+  {                                                                           
+    "id": 139,                                                              
+    "prompt": "food that hits different at midnight",                       
+    "difficulty": "medium"                                                    
+  },                                                                          
+  {
+    "id": 140,
+    "prompt": "thing people say when they have nothing to say",
+    "difficulty": "medium"
+  },
+  {
+    "id": 141,
+    "prompt": "worst thing to forget",
+    "difficulty": "medium"
+  },
+  {
+    "id": 142,
+    "prompt": "thing that feels illegal but isn't",
+    "difficulty": "medium"
+  },
+  {
+    "id": 143,
+    "prompt": "a texture",
+    "difficulty": "hard"
+  },
+  {
+    "id": 144,
+    "prompt": "a feeling you can't name",
+    "difficulty": "hard"
+  },
+  {
+    "id": 145,
+    "prompt": "something that doesn't exist but should",
+    "difficulty": "hard"
+  },
+  {
+    "id": 146,
+    "prompt": "the most \"human\" thing",
+    "difficulty": "hard"
+  },
+  {
+    "id": 147,
+    "prompt": "a word that sounds like what it means",
+    "difficulty": "hard"
+  },
+  {
+    "id": 148,
+    "prompt": "thing everyone thinks but nobody says",
+    "difficulty": "hard"
+  },
+  {
+    "id": 149,
+    "prompt": "something you'd put in a time capsule",
+    "difficulty": "hard"
+  },
+  {
+    "id": 150,
+    "prompt": "the most universal experience",
+    "difficulty": "hard"
+  },
+  {
+    "id": 151,
+    "prompt": "something that peaked",
+    "difficulty": "hard"
+  },
+  {
+    "id": 152,
+    "prompt": "thing that's only fun the first time",
+    "difficulty": "hard"
+  },
+  {
+    "id": 153,
+    "prompt": "a vibe",
+    "difficulty": "hard"
+  },
+  {
+    "id": 154,
+    "prompt": "something you outgrew",
+    "difficulty": "hard"
+  },
+  {
+    "id": 155,
+    "prompt": "the scariest non-scary thing",
+    "difficulty": "hard"
+  },
+  {                                                                           
+    "id": 156,                                                              
+    "prompt": "thing that's better in theory than in practice",               
+    "difficulty": "hard"                                                    
+  },                                                                        
+  {                                                                         
+    "id": 157,                                                                
+    "prompt": "something everyone romanticizes",                              
+    "difficulty": "hard"
+  },
+  {
+    "id": 158,
+    "prompt": "a memory everyone has",
+    "difficulty": "hard"
+  },
+  {
+    "id": 159,
+    "prompt": "thing you'd rename if you could",
+    "difficulty": "hard"
+  },
+  {
+    "id": 160,
+    "prompt": "something that's quietly disappearing",
+    "difficulty": "hard"
+  },
+  {
+    "id": 161,
+    "prompt": "the most overrated advice",
+    "difficulty": "hard"
+  },
+  {
+    "id": 162,
+    "prompt": "something you believe but can't prove",
+    "difficulty": "hard"
+  },
+  {
+    "id": 163,
+    "prompt": "a place that's a feeling",
+    "difficulty": "hard"
+  },
+  {
+    "id": 164,
+    "prompt": "thing that hits harder as you get older",
+    "difficulty": "hard"
+  },
+  {
+    "id": 165,
+    "prompt": "something that was better before the internet",
+    "difficulty": "hard"
+  },
+  {
+    "id": 166,
+    "prompt": "the loneliest thing",
+    "difficulty": "hard"
+  },
+  {
+    "id": 167,
+    "prompt": "something you'd tell your younger self",
+    "difficulty": "hard"
+  },
+  {
+    "id": 168,
+    "prompt": "a word that lost its meaning",
+    "difficulty": "hard"
+  },
+  {
+    "id": 169,
+    "prompt": "thing people only do when nobody's watching",
+    "difficulty": "hard"
+  },
+  {
+    "id": 170,
+    "prompt": "something that shouldn't work but does",
+    "difficulty": "hard"
+  },
+  {
+    "id": 171,
+    "prompt": "the most forgettable thing",
+    "difficulty": "hard"
+  },
+  {
+    "id": 172,
+    "prompt": "a sound from your childhood",
+    "difficulty": "hard"
+  },
+  {
+    "id": 173,
+    "prompt": "thing that only exists at 3am",
+    "difficulty": "hard"
+  },
+  {
+    "id": 174,
+    "prompt": "the most human invention",
+    "difficulty": "hard"
   }
+
 ]


### PR DESCRIPTION
## Summary
- Added 53 new category prompts (IDs 122–174)
- Mix of easy, medium, and hard difficulties
- Includes abstract/philosophical hard prompts, social/personality medium prompts, and straightforward easy prompts

## Test plan
- [ ] Run game and verify new categories appear in rotation
- [ ] Check that difficulty scheduling still works correctly with the larger pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)