### PR TITLE
Add postinstall hook for ollama and nomic-embed-text setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev:server": "tsx --watch src/server.ts",
     "dev:client": "vite",
     "build": "vite build",
-    "start": "tsx src/server.ts"
+    "start": "tsx src/server.ts",
+    "setup-ollama": "bash scripts/setup-ollama.sh",
+    "postinstall": "bash scripts/setup-ollama.sh"
   },
   "dependencies": {
     "howler": "^2.2.4",

--- a/scripts/setup-ollama.sh
+++ b/scripts/setup-ollama.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+MODEL="nomic-embed-text"
+
+# Check if ollama is installed
+if ! command -v ollama &> /dev/null; then
+    echo ""
+    echo "  ollama is not installed."
+    echo "  This project uses ollama for text embeddings (scoring)."
+    echo ""
+    echo "  Install from: https://ollama.com/download"
+    echo "  Then run:     npm run setup-ollama"
+    echo ""
+    exit 0
+fi
+
+# Check if ollama is running (ollama list fails if server is down)
+if ! ollama list &> /dev/null 2>&1; then
+    echo ""
+    echo "  ollama is installed but not running."
+    echo "  Start it with: ollama serve"
+    echo "  Then run:      npm run setup-ollama"
+    echo ""
+    exit 0
+fi
+
+# Check if the model is already pulled
+if ollama list | grep -q "$MODEL"; then
+    echo "  ollama ready: $MODEL model found"
+else
+    echo "  Pulling $MODEL model (this may take a minute)..."
+    ollama pull "$MODEL"
+    if [ $? -eq 0 ]; then
+        echo "  $MODEL model installed successfully"
+    else
+        echo ""
+        echo "  Failed to pull $MODEL."
+        echo "  Run manually: ollama pull $MODEL"
+        echo ""
+    fi
+fi


### PR DESCRIPTION
Checks if ollama is installed and running, pulls the nomic-embed-text model if missing. Exits gracefully without breaking npm install if ollama is unavailable. Also available as npm run setup-ollama for manual use.