### PR TITLE
fix: Timer hooks violation in Lobby countdown

### DIFF
--- a/src/client/Lobby.tsx
+++ b/src/client/Lobby.tsx
@@ -74,7 +74,7 @@ export function Lobby({ mailbox, playerId, gameId, isReady, secsLeft, mood, play
         ))}
       </ul>
       {secsLeft !== undefined
-        && <p>Starting in {Timer({ secsLeft })}...</p>}
+        && <p>Starting in <Timer secsLeft={secsLeft} />...</p>}
       <MoodPicker currentMood={currentMood} onSelect={handleMoodChange} />
       <button onClick={handleToggleReady}>
         {isReady.find(([id]) => id === playerId)?.[1] ? 'Unready' : 'Ready'}


### PR DESCRIPTION
## Summary

- Timer was called as a function `{Timer({ secsLeft })}` inside a conditional, causing React's "rendered more hooks than previous render" error when the lobby countdown started
- Changed to proper JSX element `<Timer secsLeft={secsLeft} />` so React manages its hook lifecycle

## Test plan

- [ ] Start a game, have all players ready up — lobby countdown should display without crashing
- [ ] Verify countdown renders correctly and transitions to guesses phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)