### PR TITLE
fix: resolve merge conflict artifacts in Lobby.tsx

### DIFF
--- a/src/client/Lobby.tsx
+++ b/src/client/Lobby.tsx
@@ -120,13 +120,11 @@ export function Lobby({ mailbox, playerId, gameId, isReady, secsLeft, mood, play
         )}
       </div>
       {secsLeft !== undefined
-        && <p>Starting in {Timer({ secsLeft })}...</p>}
-      <div className="screen-footer">
-        <button className="btn" onClick={handleToggleReady}>
         && <p>Starting in <Timer secsLeft={secsLeft} />...</p>}
-      <MoodPicker currentMood={currentMood} onSelect={handleMoodChange} />
-      <button onClick={handleToggleReady}>
-        {isReady.find(([id]) => id === playerId)?.[1] ? 'Unready' : 'Ready'}
+      <div className="screen-footer">
+        <MoodPicker currentMood={currentMood} onSelect={handleMoodChange} />
+        <button className="btn" onClick={handleToggleReady}>
+          {isReady.find(([id]) => id === playerId)?.[1] ? 'Unready' : 'Ready'}
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Bad merge left duplicate Timer lines (old function call + new JSX element) and a duplicate button in the return block
- Kept the correct `<Timer secsLeft={secsLeft} />` JSX version, removed the old `{Timer({ secsLeft })}` duplicate
- Restored screen-footer structure with MoodPicker and single Ready button

## Test plan

- [ ] Lobby renders without errors
- [ ] Countdown displays when all players ready up
- [ ] Transitions to guesses phase cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)