### PR TITLE
fix: move clipboard.writeText into onClick handler

### DIFF
--- a/src/client/Lobby.tsx
+++ b/src/client/Lobby.tsx
@@ -78,9 +78,8 @@ export function Lobby({ mailbox, playerId, gameId, isReady, secsLeft, mood, play
 
   function copyUrlButton(id: string): JSX.Element {
     const gameUrl = `${window.location.origin}/game/${id}`
-    navigator.clipboard.writeText(gameUrl)
     return (<>
-      <button className="btn-icon" popoverTarget="copy-popover">
+      <button className="btn-icon" popoverTarget="copy-popover" onClick={() => navigator.clipboard.writeText(gameUrl)}>
         <svg className="icon" width="18" height="18" viewBox="0 0 24 24" fill="none"         
           stroke="currentColor" strokeWidth="2" strokeLinecap="round"               
           strokeLinejoin="round">                                                    


### PR DESCRIPTION
## Summary

- `navigator.clipboard.writeText()` in `copyUrlButton` was firing on every render instead of on click
- Moved it into the button's `onClick` handler so it only triggers when the user clicks

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)