### PR TITLE
fix: scope-conflict checks for issue creation and startwork

### DIFF
--- a/.claude/commands/startwork.md
+++ b/.claude/commands/startwork.md
@@ -49,6 +49,11 @@ know about before choosing:
 
 - **Duplicates** — search open PRs and in-progress board items for
   overlapping scope. Flag any items that already have work in flight.
+- **Scope conflicts** — for each candidate, check ALL non-Done issues
+  for overlapping domain. Flag when a candidate answers, implements,
+  or presupposes decisions from another open issue — especially when
+  an `agent-resolvable` task overlaps with an unresolved
+  `human-decision` or `architecture` issue.
 - **Blockers** — check for unresolved blocking conditions (see
   definitions below). Flag but don't hide blocked items.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,11 +115,16 @@ Add a `### Dependencies` section to the issue body:
 ```
 
 ### When creating issues
-Before creating a new issue, the agent should:
-1. Search open issues for overlapping scope (`gh issue list --search "<keywords>"`)
-2. If a dependency exists, add it to the Dependencies section
-3. If the dependency is unresolved, add the `blocked` label
-4. Link the issues bidirectionally (add a comment on the blocking issue too)
+Before creating a new issue, the agent must:
+1. Search ALL open issues (any status except Done) for overlapping scope
+   (`gh issue list --search "<keywords>"`)
+2. For each match, classify: **blocks**, **depends on**, or **duplicates**.
+   An implementation task that presupposes answers to an open
+   `human-decision` issue is a dependency.
+3. Add matches to a `### Dependencies` section in the new issue body
+4. Link bidirectionally (comment on the related issue too)
+5. If a blocking dependency is unresolved, add `blocked` label and do
+   NOT mark the new issue as "Ready"
 
 ### When closing issues
 After an issue closes, check for issues with `blocked` label that


### PR DESCRIPTION
## Summary
- Strengthened issue creation protocol in CLAUDE.md: must check ALL open issues for overlap, classify relationships, and block if dependency is unresolved
- Added "Scope conflicts" screening step to startwork.md: cross-references candidates against non-Done issues for domain overlap (especially agent-resolvable vs human-decision conflicts)

Prompted by #65 (Scoring MVP) sitting in Ready while #27 (scoring algorithm design) was still open — the overlap wasn't caught by the existing checks.

## Test plan
- [x] Run `/startwork` and verify scope-conflict screening surfaces overlapping issues
- [ ] Create a test issue with overlapping scope and verify the creation protocol catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)