### PR TITLE
fix: require board registration when creating issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,8 @@ Before creating a new issue, the agent must:
 4. Link bidirectionally (comment on the related issue too)
 5. If a blocking dependency is unresolved, add `blocked` label and do
    NOT mark the new issue as "Ready"
+6. Add the issue to the project board
+   (`gh project item-add 1 --owner thrialectics --url <issue-url>`)
 
 ### When closing issues
 After an issue closes, check for issues with `blocked` label that


### PR DESCRIPTION
## Summary
- Added step 6 to CLAUDE.md issue creation protocol: agents must `gh project item-add` every new issue to the project board
- Prevents orphaned issues (14 were found missing from the board today)

## Test plan
- [x] Verified all 14 orphaned issues are now on the board
- [ ] Next agent-created issue should automatically be added to the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)