### PR TITLE
fix: add maxLength to name inputs

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -113,6 +113,7 @@ function App({ gameId }: Props) {
           <input className="input"
             type="text"
             placeholder="Your name"
+            maxLength={20}
             value={nameInput}
             autoFocus
             onChange={e => setNameInput(e.target.value)}

--- a/src/client/Lounge.tsx
+++ b/src/client/Lounge.tsx
@@ -45,6 +45,7 @@ export function Lounge({ mailbox, playerId, mood, otherPlayers }: Props) {
           <input className="input"
             type="text"
             placeholder="Your name"
+            maxLength={20}
             value={playerName}
             onChange={e => setPlayerName(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && handleJoin()}


### PR DESCRIPTION
## Summary
- Adds `maxLength={20}` to both name inputs (Lounge screen and join-via-URL screen)
- Prevents unbounded names from breaking avatar display, player lists, and WebSocket payloads

Closes #102

## Test plan
- [ ] Enter a name longer than 20 characters on the Lounge screen — input should stop at 20
- [ ] Enter a name longer than 20 characters on the join-via-URL screen — same behavior