### PR TITLE
fix: add visual feedback after guess submission

### DIFF
--- a/src/client/Guesses.tsx
+++ b/src/client/Guesses.tsx
@@ -15,8 +15,20 @@ const colors = [
     '--purple', '--purple-light',
   ]
 
-function GuessInput(props: { onSubmit: (guess: string) => void }) {
+function GuessInput(props: { onSubmit: (guess: string) => void, locked: boolean }) {
   const [guess, setGuess] = React.useState('')
+
+  function handleLockIn() {
+    if (guess) props.onSubmit(guess)
+  }
+
+  if (props.locked) {
+    return (
+      <div className="screen-footer locked-in">
+        <p className="locked-in-msg">Locked in!</p>
+      </div>
+    )
+  }
 
   return (
     <div className="screen-footer">
@@ -26,8 +38,9 @@ function GuessInput(props: { onSubmit: (guess: string) => void }) {
         type="text"
         value={guess}
         onChange={(e) => setGuess(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleLockIn()}
       />
-      <button className="btn" onClick={() => guess && props.onSubmit(guess)}>
+      <button className="btn" onClick={handleLockIn}>
         Lock In
       </button>
     </div>
@@ -96,7 +109,7 @@ export function Guesses({ mailbox, playerId, gameId, category, secsLeft, hasGues
       </div>
       <div className="screen-footer">
         <PlayerProgress hasGuessed={hasGuessed} />
-        <GuessInput onSubmit={handleSubmit} />
+        <GuessInput onSubmit={handleSubmit} locked={hasGuessed.some(([id, done]) => id === playerId && done)} />
       </div>
     </div>
   )

--- a/static/styles/guesses.css
+++ b/static/styles/guesses.css
@@ -36,3 +36,20 @@
     height: 16px;
     border-radius: 50%;
 }
+
+.locked-in {
+    justify-content: center;
+}
+
+.locked-in-msg {
+    font-family: var(--font-fancy);
+    font-size: 1.5rem;
+    color: var(--cream);
+    text-align: center;
+    opacity: 0;
+    animation: fade-in 0.3s ease forwards;
+}
+
+@keyframes fade-in {
+    to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- After locking in a guess, the input and button are replaced with a "Locked in!" confirmation message
- Locked state is derived from the server's `hasGuessed` data for the current player
- Adds a subtle fade-in animation on the confirmation text
- Also adds Enter key support on the guess input

Closes #85

## Test plan
- [ ] Submit a guess on the guesses screen — input/button should be replaced with "Locked in!" message
- [ ] The "Locked in!" text should fade in smoothly
- [ ] The player progress dots should update simultaneously
- [ ] Pressing Enter in the input field should also submit the guess