### PR TITLE
fix: persist mood across Lounge remounts

### DIFF
--- a/src/client/Lounge.tsx
+++ b/src/client/Lounge.tsx
@@ -29,6 +29,7 @@ export function Lounge({ mailbox, playerId, mood, otherPlayers }: Props) {
 
   function handleMoodChange(newMood: t.Mood) {
     setCurrentMood(newMood)
+    localStorage.setItem('mood', newMood)
     if (joined) {
       mailbox.send({ type: 'SET_PLAYER_INFO', playerId, playerName, mood: newMood })
     }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -35,6 +35,6 @@ export function initialState(): State {
     otherPlayers: [],
     playerId,
     playerName,
-    mood: '😀'
+    mood: (localStorage.getItem('mood') as t.Mood) ?? '😀'
   }
 }


### PR DESCRIPTION
## Summary
- Mood now saves to localStorage when changed and reads from it on init
- Follows the same pattern already used for `playerName` persistence
- Also fixes mood for the join-via-URL flow (reads correct mood from localStorage instead of default)

Closes #100

## Test plan
- [x] Pick a mood in the Lounge, create/join a game, play through a round, return to Lounge — mood should persist
- [x] Refresh the page — mood should persist
- [x] Clear localStorage — mood should fall back to default 😀