### PR TITLE
feat: send round number in GUESS_STATE and SCORE_STATE

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -45,10 +45,10 @@ function onMessage(state: t.State, message: t.ToClientMessage): t.State {
       return { ...state, view: { type: 'LOBBY', gameId: message.gameId, isReady: message.isReady } }
 
     case 'GUESS_STATE':
-      return { ...state, view: { type: 'GUESSES', gameId: message.gameId, hasGuessed: message.hasGuessed, category: message.category, secsLeft: message.secsLeft } }
+      return { ...state, view: { type: 'GUESSES', gameId: message.gameId, hasGuessed: message.hasGuessed, category: message.category, secsLeft: message.secsLeft, round: message.round, totalRounds: message.totalRounds } }
 
     case 'SCORE_STATE':
-      return { ...state, view: { type: 'SCORES', gameId: message.gameId, scores: message.playerScores, positions: message.positions, guesses: message.guesses, category: message.category, isReady: message.isReady, secsLeft: message.secsLeft } }
+      return { ...state, view: { type: 'SCORES', gameId: message.gameId, scores: message.playerScores, positions: message.positions, guesses: message.guesses, category: message.category, isReady: message.isReady, secsLeft: message.secsLeft, round: message.round, totalRounds: message.totalRounds } }
 
     case 'LOBBY_COUNTDOWN': {
       const isReady = state.view.type === 'LOBBY' ? state.view.isReady : []
@@ -154,6 +154,8 @@ function App({ gameId }: Props) {
         category={state.view.category}
         secsLeft={state.view.secsLeft}
         hasGuessed={state.view.hasGuessed}
+        round={state.view.round}
+        totalRounds={state.view.totalRounds}
       />
 
     case 'SCORES':
@@ -168,6 +170,8 @@ function App({ gameId }: Props) {
         otherPlayers={state.otherPlayers}
         isReady={state.view.isReady}
         secsLeft={state.view.secsLeft}
+        round={state.view.round}
+        totalRounds={state.view.totalRounds}
       />
 
     // minimal error boundary in case extra views added later

--- a/src/client/Guesses.tsx
+++ b/src/client/Guesses.tsx
@@ -62,9 +62,11 @@ type Props = {
   category: string
   secsLeft: number
   hasGuessed: [t.PlayerId, boolean][]
+  round: number
+  totalRounds: number
 }
 
-export function Guesses({ mailbox, playerId, gameId, category, secsLeft, hasGuessed }: Props) {
+export function Guesses({ mailbox, playerId, gameId, category, secsLeft, hasGuessed, round, totalRounds }: Props) {
   function handleSubmit(guess: string) {
     mailbox.send({
       type: 'GUESS',
@@ -88,7 +90,7 @@ export function Guesses({ mailbox, playerId, gameId, category, secsLeft, hasGues
       </div>
       <div className="screen-header">
         <h2>Communicate Without Speaking</h2>
-        <h1>{/*add rounds counter prop here */}</h1>
+        <h1>Round {round + 1} of {totalRounds}</h1>
         {/*should add the game id feature here */}
       </div>
       <div className="category-display">

--- a/src/client/Scores.tsx
+++ b/src/client/Scores.tsx
@@ -1,6 +1,5 @@
 import * as t from './types'
 import * as React from 'react'
-import * as config from '../config'
 import { Timer } from './components/timer'
 
 type Props = {
@@ -13,21 +12,19 @@ type Props = {
   otherPlayers: [t.PlayerId, t.PlayerName, t.Mood][]
   isReady: [string, boolean][]
   secsLeft: number | undefined
-  round?: number
+  round: number
+  totalRounds: number
   guesses?: [t.PlayerId, string][]
 }
 
 function RoundTopbar({ round, totalRounds, secsLeft }: {
-  round?: number
+  round: number
   totalRounds: number
   secsLeft?: number
 }) {
   return (
     <div className="screen-topbar">
-      {round !== undefined
-        ? <span>Round {round + 1} of {totalRounds}</span>
-        : <span />
-      }
+      <span>Round {round + 1} of {totalRounds}</span>
       {secsLeft !== undefined
         ? <span><Timer secsLeft={secsLeft} />s</span>
         : <span />
@@ -119,7 +116,7 @@ function GameOverFooter({ standings }: {
   )
 }
 
-export function Scores({ gameId, playerId, mailbox, scores, category, otherPlayers, isReady, secsLeft, round, guesses }: Props) {
+export function Scores({ gameId, playerId, mailbox, scores, category, otherPlayers, isReady, secsLeft, round, totalRounds, guesses }: Props) {
   const nameOf = new Map(otherPlayers.map(([id, name]) => [id, name]))
 
   //My data
@@ -141,7 +138,7 @@ export function Scores({ gameId, playerId, mailbox, scores, category, otherPlaye
 
   // Final standings for game-over
   // TODO: needs culumative scores, not just this round
-  const isGameOver = round !== undefined && round + 1 >= config.ROUNDS_PER_GAME
+  const isGameOver = round + 1 >= totalRounds
   const standings = allResults.map(r => ({ name: r.name, score: r.score }))
 
   const handleToggleReady = () => {
@@ -153,7 +150,7 @@ export function Scores({ gameId, playerId, mailbox, scores, category, otherPlaye
 
   return (
     <div className="screen">
-      <RoundTopbar round={round} totalRounds={config.ROUNDS_PER_GAME} secsLeft={secsLeft} />
+      <RoundTopbar round={round} totalRounds={totalRounds} secsLeft={secsLeft} />
       <CategoryHeader category={category} />
       <div className="visualization-placeholder" />
       <MyResult guess={myGuess} score={myScore} />

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -6,8 +6,8 @@ import * as t from '../types'
 export type View =
   | { type: 'LOUNGE' }
   | { type: 'LOBBY', gameId: string, isReady: [t.PlayerId, boolean][], secsLeft?: number }
-  | { type: 'GUESSES', gameId: string, hasGuessed: [t.PlayerId, boolean][], category: string, secsLeft: number, guess?: string }
-  | { type: 'SCORES', gameId: string, isReady: [t.PlayerId, boolean][], secsLeft?: number, scores: [t.PlayerId, number][], positions?: [t.PlayerId, number, number][], guesses: [t.PlayerId, string][], category: string }
+  | { type: 'GUESSES', gameId: string, hasGuessed: [t.PlayerId, boolean][], category: string, secsLeft: number, guess?: string, round: number, totalRounds: number }
+  | { type: 'SCORES', gameId: string, isReady: [t.PlayerId, boolean][], secsLeft?: number, scores: [t.PlayerId, number][], positions?: [t.PlayerId, number, number][], guesses: [t.PlayerId, string][], category: string, round: number, totalRounds: number }
 
 export type State = {
   audioPlayer: audio.Player,

--- a/src/server/play.ts
+++ b/src/server/play.ts
@@ -382,7 +382,9 @@ export function currentGameState(gameId: t.GameId, game: t.Game): t.ToClientMess
         gameId,
         category: phase.category,
         hasGuessed: game.players.map(info => [info.id, phase.guesses.has(info.id)]),
-        secsLeft: phase.secsLeft
+        secsLeft: phase.secsLeft,
+        round: phase.round,
+        totalRounds: config.ROUNDS_PER_GAME,
       }
     }
     case 'SCORES': {
@@ -396,6 +398,8 @@ export function currentGameState(gameId: t.GameId, game: t.Game): t.ToClientMess
         guesses: [...phase.guesses.entries()],
         isReady: game.players.map(info => [info.id, phase.isReady.has(info.id)]),
         secsLeft: phase.secsLeft,
+        round: phase.round,
+        totalRounds: config.ROUNDS_PER_GAME,
       }
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,8 @@ export type ToClientMessage =
   | { type: 'MEMBER_CHANGE', gameId?: GameId, allPlayers: [PlayerId, PlayerName, Mood][] }
   | { type: 'LOBBY_STATE', gameId: GameId, isReady: [PlayerId, boolean][] }
   | { type: 'LOBBY_COUNTDOWN', gameId: GameId, secsLeft: number }
-  | { type: 'GUESS_STATE', gameId: GameId, category: string, hasGuessed: [PlayerId, boolean][], secsLeft: number }
-  | { type: 'SCORE_STATE', gameId: GameId, category: string, playerScores: [PlayerId, number][], positions: [PlayerId, number, number][], guesses: [PlayerId, string][], isReady: [PlayerId, boolean][], secsLeft: number }
+  | { type: 'GUESS_STATE', gameId: GameId, category: string, hasGuessed: [PlayerId, boolean][], secsLeft: number, round: number, totalRounds: number }
+  | { type: 'SCORE_STATE', gameId: GameId, category: string, playerScores: [PlayerId, number][], positions: [PlayerId, number, number][], guesses: [PlayerId, string][], isReady: [PlayerId, boolean][], secsLeft: number, round: number, totalRounds: number }
   | { type: 'NO_SUCH_GAME', gameId: GameId }
 
 export type Response =


### PR DESCRIPTION
## Summary
- Server now sends `round` and `totalRounds` in both `GUESS_STATE` and `SCORE_STATE` wire messages
- Guesses screen displays "Round X of Y" in the header (replaces placeholder comment)
- Scores screen receives round info via props instead of importing config directly
- Removed unused `config` import from Scores.tsx

Closes #86

## Test plan
- [ ] Start a game — Guesses screen should show "Round 1 of 10"
- [ ] Play through to round 2 — counter should update to "Round 2 of 10"
- [ ] Scores screen should also show the correct round number
- [ ] Final round (10 of 10) transitions to game over correctly