### PR TITLE
fix: disable mobile zoom and lock viewport scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
     <title>Schelling Points</title>
   </head>

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="StyleSheet" href="/static/styles.css" type="text/css" media="screen">
     <title>Schelling Points</title>
   </head>


### PR DESCRIPTION
## Summary
- Add `maximum-scale=1.0, user-scalable=no` to viewport meta in both `index.html` and `static/index.html`
- Prevents auto-zoom and pinch-to-zoom on mobile for app-like experience

## Test plan
- [ ] Page loads at 1:1 scale on mobile
- [ ] No pinch-to-zoom possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)